### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bugs.md
+++ b/.github/ISSUE_TEMPLATE/01_bugs.md
@@ -19,7 +19,7 @@ Also, be sure to check our documentation first: https://github.com/Digitaler-Imp
 ## Technical details
 
 - Device name:
-- iOS version:
+- OS version:
 - App version:
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/01_bugs.md
+++ b/.github/ISSUE_TEMPLATE/01_bugs.md
@@ -1,0 +1,50 @@
+---
+name: "\U0001F6A8 Bug Report"
+about: Did you come across a bug or unexpected behaviour differing from the docs?
+labels: bug
+
+---
+<!--
+Thanks for reporting a bug 🙌 ❤️
+
+Before opening a new issue, please make sure that we do not have any duplicates already open. You can ensure this by searching the issue list for this repository. If there is a duplicate, please close your issue and add a comment to the existing issue instead.
+
+Also, be sure to check our documentation first: https://github.com/Digitaler-Impfnachweis/documentation
+-->
+
+## Avoid duplicates
+* [ ] Bug is not mentioned in the [FAQ](https://digitaler-impfnachweis-app.de/faq/)
+* [ ] Bug is not already reported in another issue
+
+## Technical details
+
+- Device name:
+- iOS version:
+- App version:
+
+## Describe the bug
+
+<!-- Describe your issue -->
+
+## Steps to reproduce the issue
+
+<!-- include screenshots, logs, code or other info to help explain your problem -->
+
+<!--
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+## Expected behaviour
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Possible Fix
+
+<!--- Not obligatory, but suggest a fix or reason for the bug -->
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/02_enhancement.md
+++ b/.github/ISSUE_TEMPLATE/02_enhancement.md
@@ -1,0 +1,23 @@
+---
+name: "\u23F1\uFE0F Enhancement Request"
+about: Do you have an idea for an enhancement?
+labels: enhancement
+
+---
+<!--
+Thanks for proposing an enhancement 🙌 ❤️
+
+Before opening a new issue, please make sure that we do not have any duplicates already open. You can ensure this by searching the issue list for this repository. If there is a duplicate, please close your issue and add a comment to the existing issue instead.
+-->
+
+## Avoid duplicates
+* [ ] This enhancement request has not already been raised before
+
+## Current Implementation
+<!-- Describe or point to the current implementation that you would like to see improved -->
+
+## Suggested Enhancement
+<!-- Outline the idea of your enhancement, by e.g., describing the algorithm you propose. You can also create a Pull Request to outline your idea -->
+
+## Expected Benefits
+<!-- Summarize how your enhancement could aid the implementation (performance, readability, memory consumption, battery consumption, etc.). Please also back up with measurements or give detailed explanations for reduced runtimes, memory consumption, etc.  -->

--- a/.github/ISSUE_TEMPLATE/03_questions.md
+++ b/.github/ISSUE_TEMPLATE/03_questions.md
@@ -1,0 +1,21 @@
+---
+name: "\U00002753 Questions?"
+about: If you have *specific* questions about pieces of the code or documentation for this component, please post them here.
+labels: question
+
+---
+<!--
+Thanks for submitting your question 🙌 ❤️
+
+Before opening a new issue, please make sure that we do not have any duplicates already open. You can ensure this by searching the issue list for this repository. If there is a duplicate, please close your issue and add a comment to the existing issue instead. Also, please, have a look at our FAQs and existing questions before opening a new question.
+-->
+
+## Avoid duplicates
+* [ ] Question is not already answered in the [FAQ](https://digitaler-impfnachweis-app.de/faq/)
+* [ ] Question has not already been asked in another issue
+
+## Your Question
+<!-- Include details about your question. -->
+* Source File:
+* Line(s):
+* Question:

--- a/.github/ISSUE_TEMPLATE/04_other.md
+++ b/.github/ISSUE_TEMPLATE/04_other.md
@@ -1,0 +1,12 @@
+---
+name: "\U0001F4AC Anything else?"
+about: For conceptual questions, please consider to open an issue in the documentation repository.
+
+---
+<!--
+Thanks for contributing to the project 🙌 ❤️
+
+Before opening a new issue, please make sure that we do not have any duplicates already open. You can ensure this by searching the issue list for this repository. If there is a duplicate, please close your issue and add a comment to the existing issue instead.
+-->
+
+* [ ] None of the other issue templates apply to this issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true


### PR DESCRIPTION
This PR adds issue templates.

I took the issue templates from the https://github.com/corona-warn-app/cwa-app-ios repository and adapted them to this project. I asked for permission to use these templates in https://github.com/corona-warn-app/cwa-documentation/issues/652 and the feedback was that this is ok. 

If you have any change requests, please, let me know. 
If you like these issue templates, it would be no problem for me to also open a PR in the other repositories here. 

Thank you for your great work! 