### PR TITLE
Adds comma to reverse representation of full name

### DIFF
--- a/Source/CovPassCommon/Sources/CovPassCommon/Models/Name.swift
+++ b/Source/CovPassCommon/Sources/CovPassCommon/Models/Name.swift
@@ -30,10 +30,10 @@ public class Name: Codable {
     }
     public var fullNameReverse: String {
         if let gn = gn, let fn = fn {
-            return "\(fn) \(gn)"
+            return "\(fn), \(gn)"
         }
         if let gnt = gnt {
-            return"\(fnt) \(gnt)"
+            return"\(fnt), \(gnt)"
         }
         return fnt
     }


### PR DESCRIPTION
A comma (`,`) is used to differentiate between the full name (given name(s) followed by family name) and its reverse form (family name followed by given name(s)):
 
- Full name: `Max Mustermann`
- Full name reversed: `Mustermann, Max`

Even the [localized texts](https://github.com/Digitaler-Impfnachweis/covpass-ios/blob/ece6dbf95ab5f71920d561be4709118384127de3/Source/CovPassApp/Source/Resources/Locale/de.lproj/Localizable.strings#L193) mention the `,`, e.g. `"certificates_overview_personal_data_name" = "Name, Vorname / Name, first name";`

Currently, the reverse form is displayed in the App as `Mustermann Max`. The Android implementation has implemented this correctly with tests for both forms, see [CovCertificateTest.kt#L38-L60](https://github.com/Digitaler-Impfnachweis/covpass-android/blob/0ef39462ba162303a156942aedb468c7de353ba7/covpass-sdk/src/test/java/de/rki/covpass/sdk/cert/models/CovCertificateTest.kt#L38-L60).

This PR adds the missing comma.