### PR TITLE
Remove special characters from PDF filename but allow letters and digits

### DIFF
--- a/Source/CovPassCommon/Sources/CovPassCommon/Extensions/String+Escaping.swift
+++ b/Source/CovPassCommon/Sources/CovPassCommon/Extensions/String+Escaping.swift
@@ -10,9 +10,10 @@ import Foundation
 
 public extension String {
     var sanitizedFileName: String {
-        let allowed = NSMutableCharacterSet.alphanumeric()
-        allowed.addCharacters(in: "-._")
-        return addingPercentEncoding(withAllowedCharacters: allowed as CharacterSet) ?? self
+        // Allow all letters, any digits, ., _, - and remove everything else
+        guard let regex = try? NSRegularExpression(pattern: "[^\\p{L}|\\d|\\.|_|-]", options: NSRegularExpression.Options.caseInsensitive) else { return self }
+        let range = NSMakeRange(0, self.count)
+        return regex.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: "")
     }
 
     var sanitizedXMLString: String {

--- a/Source/CovPassCommon/Sources/CovPassCommon/Extensions/String+Escaping.swift
+++ b/Source/CovPassCommon/Sources/CovPassCommon/Extensions/String+Escaping.swift
@@ -11,7 +11,7 @@ import Foundation
 public extension String {
     var sanitizedFileName: String {
         // Allow all letters, any digits, ., _, - and remove everything else
-        guard let regex = try? NSRegularExpression(pattern: "[^\\p{L}|\\d|\\.|_|-]", options: NSRegularExpression.Options.caseInsensitive) else { return self }
+        guard let regex = try? NSRegularExpression(pattern: "[^\\p{L}|\\d|\\.|_|-]", options: .caseInsensitive) else { return self }
         let range = NSMakeRange(0, self.count)
         return regex.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: "")
     }

--- a/Source/CovPassCommon/Tests/CovPassCommonTests/Extensions/String+Filename.swift
+++ b/Source/CovPassCommon/Tests/CovPassCommonTests/Extensions/String+Filename.swift
@@ -16,14 +16,15 @@ import XCTest
 class StringFilenameTests: XCTestCase {
     func testFilenameSanitizer() {
         XCTAssertEqual("file.txt".sanitizedFileName, "file.txt")
-
-        XCTAssertEqual("file/.txt".sanitizedFileName, "file%2F.txt")
-        XCTAssertEqual("file\\.txt".sanitizedFileName, "file%5C.txt")
-        XCTAssertEqual("file^.txt".sanitizedFileName, "file%5E.txt")
+        XCTAssertEqual("file/.txt".sanitizedFileName, "file.txt")
+        XCTAssertEqual("file\\.txt".sanitizedFileName, "file.txt")
+        XCTAssertEqual("file^.txt".sanitizedFileName, "file.txt")
         XCTAssertEqual(".file.txt".sanitizedFileName, ".file.txt")
-
-        XCTAssertEqual("~/file.txt".sanitizedFileName, "%7E%2Ffile.txt")
-        XCTAssertEqual("/file.txt".sanitizedFileName, "%2Ffile.txt")
+        XCTAssertEqual("~/file.txt".sanitizedFileName, "file.txt")
+        XCTAssertEqual("/file.txt".sanitizedFileName, "file.txt")
+        XCTAssertEqual("_-file.txt".sanitizedFileName, "_-file.txt")
+        XCTAssertEqual("!@#%$^&*=~\"\\<>+{}()[]/:;'`?,".sanitizedFileName, "")
+        XCTAssertEqual("aouäöüÄÖÜß.pdf".sanitizedFileName, "aouäöüÄÖÜß.pdf")
     }
 
     func testPathTraversing() {
@@ -39,6 +40,7 @@ class StringFilenameTests: XCTestCase {
 
         // check if all escaped file names stay in `tempDir`
         BLNS.testStrings.forEach { string in
+            if string.sanitizedFileName.isEmpty { return }
             let checkFile = tempDir.appendingPathComponent(string.sanitizedFileName)
             let checkDir = checkFile.standardizedFileURL.deletingLastPathComponent()
 


### PR DESCRIPTION
Currently PDF names with German umlaut are not displayed correctly

**Example**
`Certificate-Timo-K%C3%B6nig` instead of `Certificate-Timo-König`


This change will allow `all letters`, `any digits`, `_`, `-`, `.` and removes everything else