### PR TITLE
Fallback to systemFont when custom font is not available

### DIFF
--- a/Source/CovPassUI/Sources/CovPassUI/Extensions/NSAttributedString+ShortCuts.swift
+++ b/Source/CovPassUI/Sources/CovPassUI/Extensions/NSAttributedString+ShortCuts.swift
@@ -29,7 +29,7 @@ public extension NSAttributedString {
             try? UIFont.loadCustomFonts()
         }
 
-        guard let font = UIFont(name: fontName, size: size) else { fatalError("Error loading font with name \(fontName)") }
+        let font = UIFont(name: fontName, size: size) ?? UIFont.systemFont(ofSize: size)
 
         let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
         let scaledFont = fontMetrics.scaledFont(for: font, compatibleWith: traitCollection)


### PR DESCRIPTION
As described in #74, this PR falls back to the system font when a desired custom font is not available.

This does not fix the underlying problem that OpenSans can't be used when it is already present on the system, but at least it avoids crashes on affected systems.