### PR TITLE
Compare names by transliterated full name

### DIFF
--- a/Source/CovPassCommon/Sources/CovPassCommon/Models/Name.swift
+++ b/Source/CovPassCommon/Sources/CovPassCommon/Models/Name.swift
@@ -86,6 +86,6 @@ public class Name: Codable {
 
 extension Name: Equatable {
     public static func == (lhs: Name, rhs: Name) -> Bool {
-        return lhs.fullName == rhs.fullName
+        return lhs.fullNameTransliterated == rhs.fullNameTransliterated
     }
 }

--- a/Source/CovPassCommon/Tests/CovPassCommonTests/Models/NameTests.swift
+++ b/Source/CovPassCommon/Tests/CovPassCommonTests/Models/NameTests.swift
@@ -30,12 +30,12 @@ class NameTests: XCTestCase {
 
         name1 = sut
         name2 = sut
-        name2.gn = "foo"
+        name2.gnt = "foo"
         XCTAssertNotEqual(name1, name2)
 
         name1 = sut
         name2 = sut
-        name2.fn = "foo"
+        name2.fnt = "foo"
         XCTAssertNotEqual(name1, name2)
 
         name1 = sut
@@ -51,6 +51,26 @@ class NameTests: XCTestCase {
         name2.gn = nil
         name2.fnt = "foo"
         XCTAssertNotEqual(name1, name2)
+
+        name1 = sut
+        name2 = sut
+        name1.fn = "FOO"
+        name1.fnt = "FOO"
+        name2.fn = "foo"
+        name2.fnt = "FOO"
+        XCTAssertEqual(name1, name2)
+
+        name1 = sut
+        name2 = sut
+        let name3 = sut
+        name1.fn = "Dörte"
+        name1.fnt = "DOERTE"
+        name2.fn = "Dorte"
+        name2.fnt = "DOERTE"
+        name3.fn = "Doerte"
+        name3.fnt = "DOERTE"
+        XCTAssertEqual(name1, name2)
+        XCTAssertEqual(name1, name3)
     }
 
     func testTrim() {


### PR DESCRIPTION
Some countries or test providers seem to be capitalizing the non-standardized last name. For example, in an Austrian test certificate, I can see `LASTNAME` for both `fn` and `fnt`, whereas Germany uses `Lastname` in `fn` and `LASTNAME` in `fnt`.

This should also increase the chance of a match for certificates issued for users having non-ASCII characters in their name, especially when issued in other countries where keyboard layouts are different.