### PR TITLE
Reorganize sections in issue templates to improve readability

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bugs.md
+++ b/.github/ISSUE_TEMPLATE/01_bugs.md
@@ -2,8 +2,8 @@
 name: "\U0001F6A8 Bug Report"
 about: Did you come across a bug or unexpected behaviour differing from the docs?
 labels: bug
-
 ---
+
 <!--
 Thanks for reporting a bug 🙌 ❤️
 
@@ -12,19 +12,15 @@ Before opening a new issue, please make sure that we do not have any duplicates 
 Also, be sure to check our documentation first: https://github.com/Digitaler-Impfnachweis/documentation
 -->
 
-## Avoid duplicates
-* [ ] Bug is not mentioned in the [FAQ](https://digitaler-impfnachweis-app.de/faq/)
-* [ ] Bug is not already reported in another issue
+## Describe the bug
+
+<!-- Describe your issue -->
 
 ## Technical details
 
 - Device name:
 - OS version:
 - App version:
-
-## Describe the bug
-
-<!-- Describe your issue -->
 
 ## Steps to reproduce the issue
 
@@ -48,3 +44,8 @@ Also, be sure to check our documentation first: https://github.com/Digitaler-Imp
 ## Additional context
 
 <!-- Add any other context about the problem here. -->
+
+## Avoid duplicates
+
+- [ ] Bug is not mentioned in the [FAQ](https://digitaler-impfnachweis-app.de/faq/)
+- [ ] Bug is not already reported in another issue

--- a/.github/ISSUE_TEMPLATE/02_enhancement.md
+++ b/.github/ISSUE_TEMPLATE/02_enhancement.md
@@ -2,22 +2,26 @@
 name: "\u23F1\uFE0F Enhancement Request"
 about: Do you have an idea for an enhancement?
 labels: enhancement
-
 ---
+
 <!--
 Thanks for proposing an enhancement 🙌 ❤️
 
 Before opening a new issue, please make sure that we do not have any duplicates already open. You can ensure this by searching the issue list for this repository. If there is a duplicate, please close your issue and add a comment to the existing issue instead.
 -->
 
-## Avoid duplicates
-* [ ] This enhancement request has not already been raised before
-
 ## Current Implementation
+
 <!-- Describe or point to the current implementation that you would like to see improved -->
 
 ## Suggested Enhancement
+
 <!-- Outline the idea of your enhancement, by e.g., describing the algorithm you propose. You can also create a Pull Request to outline your idea -->
 
 ## Expected Benefits
+
 <!-- Summarize how your enhancement could aid the implementation (performance, readability, memory consumption, battery consumption, etc.). Please also back up with measurements or give detailed explanations for reduced runtimes, memory consumption, etc.  -->
+
+## Avoid duplicates
+
+- [ ] This enhancement request has not already been raised before

--- a/.github/ISSUE_TEMPLATE/03_questions.md
+++ b/.github/ISSUE_TEMPLATE/03_questions.md
@@ -2,20 +2,23 @@
 name: "\U00002753 Questions?"
 about: If you have *specific* questions about pieces of the code or documentation for this component, please post them here.
 labels: question
-
 ---
+
 <!--
 Thanks for submitting your question 🙌 ❤️
 
 Before opening a new issue, please make sure that we do not have any duplicates already open. You can ensure this by searching the issue list for this repository. If there is a duplicate, please close your issue and add a comment to the existing issue instead. Also, please, have a look at our FAQs and existing questions before opening a new question.
 -->
 
-## Avoid duplicates
-* [ ] Question is not already answered in the [FAQ](https://digitaler-impfnachweis-app.de/faq/)
-* [ ] Question has not already been asked in another issue
-
 ## Your Question
+
 <!-- Include details about your question. -->
-* Source File:
-* Line(s):
-* Question:
+
+- Source File:
+- Line(s):
+- Question:
+
+## Avoid duplicates
+
+- [ ] Question is not already answered in the [FAQ](https://digitaler-impfnachweis-app.de/faq/)
+- [ ] Question has not already been asked in another issue

--- a/.github/ISSUE_TEMPLATE/04_other.md
+++ b/.github/ISSUE_TEMPLATE/04_other.md
@@ -1,12 +1,12 @@
 ---
 name: "\U0001F4AC Anything else?"
 about: For conceptual questions, please consider to open an issue in the documentation repository.
-
 ---
+
 <!--
 Thanks for contributing to the project 🙌 ❤️
 
 Before opening a new issue, please make sure that we do not have any duplicates already open. You can ensure this by searching the issue list for this repository. If there is a duplicate, please close your issue and add a comment to the existing issue instead.
 -->
 
-* [ ] None of the other issue templates apply to this issue.
+- [ ] None of the other issue templates apply to this issue.


### PR DESCRIPTION
<!--- 
  Provide a general summary of your changes in the Title above ⬆.
  Format: 
    BVC-1234: Short summary of the changes
-->

# Description
<!--- 
  Describe your changes in detail.
  Highlight anything out of the ordinary.
  Why is this change required? What problem does it solve?
-->

Currently the issue templates always show the checkboxes first and that makes it difficult to see the bug description in the list view. I changed the order of those sections to make it more readable.

<img width="1033" alt="Screen Shot 2022-03-02 at 15 21 39" src="https://user-images.githubusercontent.com/4365095/156380631-1dad9aef-47a5-48ee-8365-2203c13bacdb.png">

